### PR TITLE
Add puget dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,8 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [mvxcvi/puget "1.3.4"]]
   :main ^:skip-aot wordle-solver.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
When following the README, `lein repl` cannot be run because it's missing the puget dependency.